### PR TITLE
[3.9] More accurate table of premium item ilvls

### DIFF
--- a/3-Items/3.9.md
+++ b/3-Items/3.9.md
@@ -62,24 +62,24 @@ For Griswold’s premium items the ilvl varies depending on what slot the items 
 
 #### Definition of `ilvl` for Griswold’s Premium Items
 
-|                 | **Diablo** | **Hellfire** |
-|---------------|------------|-------------|
-| **Slot**<sup>[^1]</sup>  | **`ilvl`**   | **`ilvl`**  |
-| 1             | `clvl - 1`  | `clvl - 1`  |
-| 2             | `clvl - 1`  | `clvl - 1`  |
-| 3             | `clvl`      | `clvl - 1`  |
-| 4             | `clvl`      | `clvl`      |
-| 5             | `clvl + 1`  | `clvl`      |
-| 6             | `clvl + 2`  | `clvl`      |
-| 7             | -           | `clvl`      |
-| 8             | -           | `clvl + 1`  |
-| 9             | -           | `clvl + 1`  |
-| 10            | -           | `clvl + 1`  |
-| 11            | -           | `clvl + 1`  |
-| 12            | -           | `clvl + 2`  |
-| 13            | -           | `clvl + 2`  |
-| 14            | -           | `clvl + 3`  |
-| 15            | -           | `clvl + 3`  |
+|                          | **Diablo** | **Hellfire (clvl 1)** | **Hellfire (clvl 2)** | **Hellfire (clvl 3)** | **Hellfire (clvl 4)** | **Hellfire (clvl 5)** | **Hellfire (clvl 6+)** |
+|--------------------------|------------|-----------------------|-----------------------|-----------------------|-----------------------|-----------------------|------------------------|
+| **Slot**<sup>[^1]</sup>  | **`ilvl`** | **`ilvl`**            | **`ilvl`**            | **`ilvl`**            | **`ilvl`**            | **`ilvl`**            | **`ilvl`**             |
+| 1                        | `clvl - 1` | `clvl - 1`            | `clvl - 1`            | `clvl - 2`            | `clvl - 2`            | `clvl - 2`            | `clvl - 2`             |
+| 2                        | `clvl - 1` | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 2`            | `clvl - 2`            | `clvl - 2`             |
+| 3                        | `clvl`     | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 2`             |
+| 4                        | `clvl`     | `clvl`                | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 1`             |
+| 5                        | `clvl + 1` | `clvl`                | `clvl`                | `clvl - 1`            | `clvl - 1`            | `clvl - 1`            | `clvl - 1`             |
+| 6                        | `clvl + 2` | `clvl`                | `clvl`                | `clvl`                | `clvl`                | `clvl - 1`            | `clvl - 1`             |
+| 7                        | -          | `clvl`                | `clvl`                | `clvl`                | `clvl`                | `clvl`                | `clvl`                 |
+| 8                        | -          | `clvl + 1`            | `clvl`                | `clvl`                | `clvl`                | `clvl`                | `clvl`                 |
+| 9                        | -          | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl`                | `clvl`                | `clvl`                 |
+| 10                       | -          | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`             |
+| 11                       | -          | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`             |
+| 12                       | -          | `clvl + 2`            | `clvl + 2`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`            | `clvl + 1`             |
+| 13                       | -          | `clvl + 2`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`             |
+| 14                       | -          | `clvl + 3`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`            | `clvl + 2`             |
+| 15                       | -          | `clvl + 3`            | `clvl + 3`            | `clvl + 3`            | `clvl + 3`            | `clvl + 3`            | `clvl + 3`             |
 
 [^1]: **There are only six slots in *Diablo*.**
 


### PR DESCRIPTION
Because Hellfire doesn't use a stable strategy for shifting items in Griswold's premium item shop, the ilvl of each slot changes relative to clvl until it finally stabilizes at clvl 6.

FYI, since the logic always generates an initial set of items at plvl 1 and then increments plvl until it matches clvl, this table of values applies to all games whether the character leveled up in that game session or not.
https://github.com/diasurgical/DevilutionX/blob/b72327b972e12dd1895cc0ea01d817163de6f4a3/Source/items.cpp#L4418-L4449